### PR TITLE
:memo: wiki link to aloof and recluse

### DIFF
--- a/toAnUnreadPoet.md
+++ b/toAnUnreadPoet.md
@@ -3,7 +3,7 @@
 ![image](https://upload.wikimedia.org/wikipedia/commons/d/d6/St.-Jerome-In-His-Study.jpg)
 I used to read your poems
 but lately you don't write
-you're silent and aloof
+you're silent and [aloof](https://en.wiktionary.org/wiki/aloof)
 you know that isn't right.
 You can't close a door once opened
 you can't abolish all your dreams
@@ -14,7 +14,7 @@ they speak the message true
 spoken from the heart
 the poems will see you through.
 A [hermit's](https://en.wikipedia.org/wiki/Hermit) not your style
-a recluse, you are not
+a [precluse](https://en.wikipedia.org/wiki/Recluse), you are not
 never give up writing
 of things that you've been taught.
 I used to read your poems


### PR DESCRIPTION
"Aloof"  doesn't have  a wikipedia page so wiki dictionaries was used instead